### PR TITLE
convert currency to number before formatting it

### DIFF
--- a/src/components/TableData.vue
+++ b/src/components/TableData.vue
@@ -103,7 +103,7 @@
         return field.length
       },
       getSumTotal(data, field) {
-        const format = amount => amount.toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,')
+        const format = amount => parseFloat(amount).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,')
         let value = data[field.field]
         if (value) {
           return format(value)


### PR DESCRIPTION
Covert the `currency` type to number before formatting it.