### PR TITLE
Custom field sorting

### DIFF
--- a/src/components/TableHeaders.vue
+++ b/src/components/TableHeaders.vue
@@ -146,6 +146,11 @@
     },
     methods: {
       sort(field) {
+        // Allow custom field sort configuration
+        if (field.sort) {
+          field.field = field.sort
+        }
+
         if (this.config.sorting.field === field.field) {
           this.config.sorting.ascending = !this.config.sorting.ascending
         }

--- a/test/specs/components/TableHeaders.spec.js
+++ b/test/specs/components/TableHeaders.spec.js
@@ -28,4 +28,29 @@ describe('TableHeaders', () => {
     expect(headers.vm.config.sorting.ascending).toBe(false)
     expect(headers.vm.config.sorting.field).toBe('name')
   })
+
+  it('sorts custom fields', () => {
+    let headers = shallowMount(TableHeaders, {
+      localVue,
+      propsData: {
+        config: {
+          sorting: {
+            field: 'index',
+            ascending: true
+          }
+        },
+        fields: [],
+        styler: () => {},
+        controls: []
+      }
+    })
+
+    headers.vm.sort({field: 'name', sort: 'xx'})
+    expect(headers.vm.config.sorting.ascending).toBe(true)
+    expect(headers.vm.config.sorting.field).toBe('xx')
+
+    headers.vm.sort({field: 'name', sort: 'xx'})
+    expect(headers.vm.config.sorting.ascending).toBe(false)
+    expect(headers.vm.config.sorting.field).toBe('xx')
+  })
 })

--- a/test/specs/components/TableHeaders.spec.js
+++ b/test/specs/components/TableHeaders.spec.js
@@ -45,6 +45,9 @@ describe('TableHeaders', () => {
       }
     })
 
+    expect(headers.vm.config.sorting.ascending).toBe(true)
+    expect(headers.vm.config.sorting.field).toBe('index')
+
     headers.vm.sort({field: 'name', sort: 'xx'})
     expect(headers.vm.config.sorting.ascending).toBe(true)
     expect(headers.vm.config.sorting.field).toBe('xx')


### PR DESCRIPTION
Custom fields were not sorting correctly.

Adds a new property for field definitions called `sort` which allows you to customise which field a certain header sorts by.

```js
// This definition will sort the custom 'name` field by the 'first_name' property
{
  type: 'custom',
  name: 'Name',
  field: 'name',
  value(data) {
    return `${data.first_name} ${data.last_name}`
  },
  header: true,
  sort: 'first_name',
  grow: 1
}
```