### PR TITLE
Search input styling

### DIFF
--- a/src/components/Searching.vue
+++ b/src/components/Searching.vue
@@ -1,26 +1,29 @@
 <template>
-  <div class="search-div">
-    <div>
-      <input
-        v-model="config.term"
-        :placeholder="config.placeholder" />
-    </div>
+  <div>
+    <input
+      v-model="config.term"
+      :placeholder="config.placeholder" />
   </div>
 </template>
 
 <style lang="scss" scoped>
-  .search-div {
-    div {
-      padding: var(--padding);
+  div {
+    padding: var(--padding);
 
-      input, input:focus {
-        color: var(--primaryText);
-        border: 1px solid var(--primary);
-      }
+    input {
+      color: var(--primaryText);
+      border: 1px solid var(--primary);
+      width: 100%;
+      height: calc(var(--padding) * 3);
+      padding: 0 calc(var(--padding) / 2);
+    }
 
-      input::placeholder {
-        color: var(--primary);
-      }
+    input:focus {
+      outline: var(--primary) auto 5px;
+    }
+
+    input::placeholder {
+      color: var(--primary);
     }
   }
 </style>


### PR DESCRIPTION
Styles the input for the search field according to the theme.

Removes a redundant div nesting and an unneeded class.

![image](https://user-images.githubusercontent.com/3657251/47031817-a6cc2200-d168-11e8-9978-c6d9e86d135a.png)
