### PR TITLE
Header Sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/data-table",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/data-table",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Vue component for rendering data-tables",
   "author": "Unicorn Global et al",
   "license": "MIT",

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -24,6 +24,7 @@
         <div class="table-card" :class="options.config.headers && options.config.headers.gap ? 'gapped' : ''">
             <table-headers
                     v-if="processedData.length && showHeaders && !smallScreen"
+                    :total-records="processedData.length"
                     :config="options.config"
                     :fields="options.fields"
                     :styler="getStyle"
@@ -412,12 +413,23 @@
       },
       compare (a, b) {
         let field = this.options.config.sorting.field
+
         if (field.includes('.')) {
           const names = field.split('.')
           // Very naive but only allow 1 dot nested depth at the moment
           a = a[names[0]]
           b = b[names[0]]
           field = names[1]
+        }
+
+        if (a === null) {
+          a = []
+          a[field] = ''
+        }
+
+        if (b === null) {
+          b = []
+          b[field] = ''
         }
 
         if (a[field] < b[field]) {

--- a/src/components/TableData.vue
+++ b/src/components/TableData.vue
@@ -5,7 +5,8 @@
             style="flex-grow: 0; flex:0;">
         <avatar-or-initials
                 class="item-avatar"
-                :size="this.$theme.rowHeight.slice(0, -2) * 0.66"
+                style="margin-left: -0.4rem; margin-right: 0.6rem; height: 35px;"
+                :size="35"
                 :image="getProperty(data, field.image)"
                 :title="getProperty(data, field.field)">
         </avatar-or-initials>

--- a/src/components/TableHeaders.vue
+++ b/src/components/TableHeaders.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="header-bar">
-    <div class="headers">
+    <div class="headers" :style="headerStyle">
       <div
         v-if="field.header"
         v-for="(field) in fields"
@@ -164,6 +164,20 @@
       controls: {
         type: Array,
         required: false
+      },
+      totalRecords: {
+        type: Number,
+        required: false,
+        default: 0
+      }
+    },
+    computed: {
+      headerStyle() {
+        if (this.totalRecords > 9) {
+          return 'margin-right: 0.7rem; margin-left: -0.1rem;'
+        }
+
+        return 'margin-right: -0.15rem; margin-left: -0.25rem;'
       }
     },
     methods: {


### PR DESCRIPTION
There was a problem when sorting columns that have computed values, for example 'custom' or 'component' columns.

Also adds a gap to the headers when the table is long enough to scroll so that alignment stays correct on both short and long datasets.